### PR TITLE
Add diagnostics

### DIFF
--- a/include/ros2_socketcan/socket_can_receiver_node.hpp
+++ b/include/ros2_socketcan/socket_can_receiver_node.hpp
@@ -81,8 +81,8 @@ private:
 
   // Diagnostic Updater
   diagnostic_updater::Updater updater_;
-  void checkRead(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  std::string errmsg_;
+  void checkSocketCanReceiverStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  std::string error_msg_;
 };
 }  // namespace socketcan
 }  // namespace drivers

--- a/include/ros2_socketcan/socket_can_receiver_node.hpp
+++ b/include/ros2_socketcan/socket_can_receiver_node.hpp
@@ -27,6 +27,8 @@
 #include <can_msgs/msg/frame.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
 
+#include <diagnostic_updater/diagnostic_updater.hpp>
+
 #include <memory>
 #include <thread>
 #include <string>
@@ -76,6 +78,11 @@ private:
   std::unique_ptr<SocketCanReceiver> receiver_;
   std::unique_ptr<std::thread> receiver_thread_;
   std::chrono::nanoseconds interval_ns_;
+
+  // Diagnostic Updater
+  diagnostic_updater::Updater updater_;
+  void checkRead(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  std::string errmsg_;
 };
 }  // namespace socketcan
 }  // namespace drivers

--- a/include/ros2_socketcan/socket_can_receiver_node.hpp
+++ b/include/ros2_socketcan/socket_can_receiver_node.hpp
@@ -76,6 +76,11 @@ private:
   std::unique_ptr<SocketCanReceiver> receiver_;
   std::unique_ptr<std::thread> receiver_thread_;
   std::chrono::nanoseconds interval_ns_;
+
+  // Diagnostic Updater
+  diagnostic_updater::Updater updater_;
+  void checkSocketCanReceiverStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  std::string error_msg_;
 };
 }  // namespace socketcan
 }  // namespace drivers

--- a/include/ros2_socketcan/socket_can_sender_node.hpp
+++ b/include/ros2_socketcan/socket_can_sender_node.hpp
@@ -27,6 +27,8 @@
 #include <can_msgs/msg/frame.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
 
+#include <diagnostic_updater/diagnostic_updater.hpp>
+
 #include <memory>
 #include <string>
 
@@ -74,6 +76,11 @@ private:
   rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr frames_sub_;
   std::unique_ptr<SocketCanSender> sender_;
   std::chrono::nanoseconds timeout_ns_;
+
+  // Diagnostic Updater
+  diagnostic_updater::Updater updater_;
+  void checkSend(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  std::string errmsg_;
 };
 }  // namespace socketcan
 }  // namespace drivers

--- a/include/ros2_socketcan/socket_can_sender_node.hpp
+++ b/include/ros2_socketcan/socket_can_sender_node.hpp
@@ -79,8 +79,8 @@ private:
 
   // Diagnostic Updater
   diagnostic_updater::Updater updater_;
-  void checkSend(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  std::string errmsg_;
+  void checkSocketCanSenderStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  std::string error_msg_;
 };
 }  // namespace socketcan
 }  // namespace drivers

--- a/include/ros2_socketcan/socket_can_sender_node.hpp
+++ b/include/ros2_socketcan/socket_can_sender_node.hpp
@@ -74,6 +74,11 @@ private:
   rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr frames_sub_;
   std::unique_ptr<SocketCanSender> sender_;
   std::chrono::nanoseconds timeout_ns_;
+
+  // Diagnostic Updater
+  diagnostic_updater::Updater updater_;
+  void checkSocketCanSenderStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  std::string error_msg_;
 };
 }  // namespace socketcan
 }  // namespace drivers

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>lifecycle_msgs</depend>
   <depend>can_msgs</depend>
+  <depend>diagnostic_updater</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/socket_can_receiver_node.cpp
+++ b/src/socket_can_receiver_node.cpp
@@ -40,7 +40,7 @@ SocketCanReceiverNode::SocketCanReceiverNode(rclcpp::NodeOptions options)
     std::chrono::duration<double>(interval_sec));
 
   // Diagnostic Updater
-  updater_.setHardwareID("ros2_socketcan");
+  updater_.setHardwareID("socket_can_receiver");
   updater_.add("socket_can_receiver", this, &SocketCanReceiverNode::checkSocketCanReceiverStatus);
   error_msg_ = "OK";
 

--- a/src/socket_can_receiver_node.cpp
+++ b/src/socket_can_receiver_node.cpp
@@ -41,8 +41,8 @@ SocketCanReceiverNode::SocketCanReceiverNode(rclcpp::NodeOptions options)
 
   // Diagnostic Updater
   updater_.setHardwareID("ros2_socketcan");
-  updater_.add("socket_can_receiver", this, &SocketCanReceiverNode::checkRead);
-  errmsg_ = "OK";
+  updater_.add("socket_can_receiver", this, &SocketCanReceiverNode::checkSocketCanReceiverStatus);
+  error_msg_ = "OK";
 
   RCLCPP_INFO(this->get_logger(), "interface: %s", interface_.c_str());
   RCLCPP_INFO(this->get_logger(), "interval(s): %f", interval_sec);
@@ -103,17 +103,17 @@ LNI::CallbackReturn SocketCanReceiverNode::on_shutdown(const lc::State & state)
   return LNI::CallbackReturn::SUCCESS;
 }
 
-void SocketCanReceiverNode::checkRead(diagnostic_updater::DiagnosticStatusWrapper & stat)
+void SocketCanReceiverNode::checkSocketCanReceiverStatus(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   using DiagStatus = diagnostic_msgs::msg::DiagnosticStatus;
   int8_t level = DiagStatus::OK;
-  if (errmsg_ == "OK") {
+  if (error_msg_ == "OK") {
       level = DiagStatus::OK;
   } else {
       level = DiagStatus::ERROR;
   }
 
-  stat.summary(level, errmsg_);
+  stat.summary(level, error_msg_);
 }
 
 void SocketCanReceiverNode::receive()
@@ -130,9 +130,9 @@ void SocketCanReceiverNode::receive()
 
     try {
       receive_id = receiver_->receive(frame_msg.data.data(), interval_ns_);
-      errmsg_ = "OK";
+      error_msg_ = "OK";
     } catch (const std::exception & ex) {
-      errmsg_ = ex.what();
+      error_msg_ = ex.what();
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), 1000,
         "Error receiving CAN message: %s - %s",

--- a/src/socket_can_sender_node.cpp
+++ b/src/socket_can_sender_node.cpp
@@ -39,7 +39,7 @@ SocketCanSenderNode::SocketCanSenderNode(rclcpp::NodeOptions options)
     std::chrono::duration<double>(timeout_sec));
 
   // Diagnostic Updater
-  updater_.setHardwareID("ros2_socketcan");
+  updater_.setHardwareID("socket_can_sender");
   updater_.add("socket_can_sender", this, &SocketCanSenderNode::checkSocketCanSenderStatus);
   error_msg_ = "OK";
 

--- a/src/socket_can_sender_node.cpp
+++ b/src/socket_can_sender_node.cpp
@@ -30,12 +30,18 @@ namespace drivers
 namespace socketcan
 {
 SocketCanSenderNode::SocketCanSenderNode(rclcpp::NodeOptions options)
-: lc::LifecycleNode("socket_can_sender_node", options)
+: lc::LifecycleNode("socket_can_sender_node", options),
+  updater_(this)
 {
   interface_ = this->declare_parameter("interface", "can0");
   double timeout_sec = this->declare_parameter("timeout_sec", 0.01);
   timeout_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
     std::chrono::duration<double>(timeout_sec));
+
+  // Diagnostic Updater
+  updater_.setHardwareID("ros2_socketcan");
+  updater_.add("socket_can_sender", this, &SocketCanSenderNode::checkSend);
+  errmsg_ = "OK";
 
   RCLCPP_INFO(this->get_logger(), "interface: %s", interface_.c_str());
   RCLCPP_INFO(this->get_logger(), "timeout(s): %f", timeout_sec);
@@ -90,6 +96,18 @@ LNI::CallbackReturn SocketCanSenderNode::on_shutdown(const lc::State & state)
   return LNI::CallbackReturn::SUCCESS;
 }
 
+void SocketCanSenderNode::checkSend(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  using DiagStatus = diagnostic_msgs::msg::DiagnosticStatus;
+  int8_t level = DiagStatus::OK;
+  if (errmsg_ == "OK") {
+      level = DiagStatus::OK;
+  } else {
+      level = DiagStatus::ERROR;
+  }
+  stat.summary(level, errmsg_);
+}
+
 void SocketCanSenderNode::on_frame(const can_msgs::msg::Frame::SharedPtr msg)
 {
   if (this->get_current_state().id() == State::PRIMARY_STATE_ACTIVE) {
@@ -106,13 +124,15 @@ void SocketCanSenderNode::on_frame(const can_msgs::msg::Frame::SharedPtr msg)
       CanId(msg->id, type, StandardFrame);
     try {
       sender_->send(msg->data.data(), msg->dlc, send_id, timeout_ns_);
+      errmsg_ = "OK";
     } catch (const std::exception & ex) {
+      errmsg_ = ex.what();
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), 1000,
         "Error sending CAN message: %s - %s",
         interface_.c_str(), ex.what());
-      return;
     }
+    updater_.force_update();
   }
 }
 


### PR DESCRIPTION
ros2_socketcanへのdiagnostic出力対応です。PRを出すのでレビューお願いいたします。

###diag対応に伴い追加したメンバ変数、関数の宣言
include/ros2_socketcan/socket_can_receiver_node.hpp
include/ros2_socketcan/socket_can_sender_node.hpp

###socketのエラー状態をdiagに通知する
src/socket_can_receiver_node.cpp
src/socket_can_sender_node.cpp