### PR TITLE
fix: unit conversion bug in to timeval (backport #24)

### DIFF
--- a/src/socket_can_common.cpp
+++ b/src/socket_can_common.cpp
@@ -82,7 +82,7 @@ struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept
   constexpr auto BILLION = 1'000'000'000LL;
   struct timeval c_timeout;
   c_timeout.tv_sec = static_cast<decltype(c_timeout.tv_sec)>(count / BILLION);
-  c_timeout.tv_usec = static_cast<decltype(c_timeout.tv_usec)>((count % BILLION) * 1000LL);
+  c_timeout.tv_usec = static_cast<decltype(c_timeout.tv_usec)>((count % BILLION) / 1000LL);
 
   return c_timeout;
 }


### PR DESCRIPTION
## Description

select関数のタイムアウト時間について、単位変換の誤りを修正する。

fork元の以下のPRの取り込みです。
https://github.com/autowarefoundation/ros2_socketcan/pull/24

**発生していた問題事象**

sockec_can_receiverについて、interval_secを0.02(単位:sec)で呼び出すと、CPU使用率が100%になり、1秒間隔でWarningが表示される。

```sh
# 起動コマンドの一例
ros2 launch ros2_socketcan socket_can_bridge.launch.xml interface:='canIMU' receiver_interval_sec:='0.02'
# or
ros2 launch ros2_socketcan socket_can_receiver.launch.py interface:='canIMU' interval_sec:='0.02'
```

```sh
# Warningメッセージ
[socket_can_receiver_node_exe-1] [WARN] [1686291362.684238888] [socket_can_receiver]: Error receiving CAN message: canIMU - Resource temporarily unavailable
```

**発生メカニズム**

select関数はソケットの準備待ち(*1)をするが、この時のタイムアウト時間はROS2のパラメータで渡される値を使う。

パラメータはdouble型(単位:sec)に対し、select関数はtimeval型でタイムアウトを設定する事から単位変換が発生する。
単位変換の途中にnanosecからmicrosecへの変換が含まれるが、1000で除算するところを乗算しており、意図しない値が代入されていた。

結果、意図しないタイムアウト時間でselect関数が呼び出され問題が生じていた。

変換の流れは以下の通り。timeval型は整数部と小数点以下を別々の構造体メンバーで保持する。
小数点以下の部分は内部で次のように変換されている。

正：0.01(s) -> 10_000_000(ns) -> 10_000(ms)
誤：0.01(s) -> 10_000_000(ns) -> 10_000_000_000(ms) 

小数部分を格納する領域に、小数の範囲を超える値が格納され意図しない動作になっていると考えられる。

*1 sockec_can_receiverはデータ読み込み可能になったか、socket_can_senderはデータ書き込み可能になったかを指す。

<!-- Write a brief description of this PR. -->

## Related links

* Jira ticket
    * [Ticket (COMPANY INTERNAL LINK)]
      * 上記のチケット作業中に発覚。

[Ticket (COMPANY INTERNAL LINK)]: https://tier4.atlassian.net/browse/AEAP-438

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

* CAN-BUSから与えるCANフレームの量を調整し、sockec_can_receiverのinterval_secが期待通り動作していることを確認。
  * 以下の事前準備を実施した後、パターン1とパターン2を実施して確認。
* sockec_can_senderのtimeout_secによりノードが意図しないWarning/Errorを検出しないことを確認。
  * Fork元のPRではsockec_can_senderの動作は言及されていないが、修正箇所の関数を使っているので確認必要と判断している。
  * 以下の事前準備を実施した後、パターン3を実施して確認。
    * 次の理由により、select関数で待ちを起こすのは困難であることから、通信を発生させて意図しないWarning/Errorを検出しないことで最低限のデグレを確認する。
      * 1つのCANデバイスを1ノードが占有することから、自分自身のsendの呼び出しが終わったら次のselect関数を呼ぶこととなる。この動きにより、書き込み待ちになりそうなタイミングでselect関数を呼ぶことが困難である。

<details><summary>事前準備</summary>
<p>

```sh
sudo apt install can-utils
sudo modprobe vcan
sudo ip link add dev vcan0 type vcan
sudo ip link set up vcan0
```

</p>
</details>

<details><summary>パターン1：interval_sec > 受信間隔</summary>
<p>

```sh
# Terminal-1
cangen vcan0 -g 19
```

```sh
# Terminal-2
top
```

```sh
# Terminal-3
ros2 launch ros2_socketcan socket_can_receiver.launch.py interface:='vcan0' interval_sec:='0.02'
```

上記を実施した状態で以下を確認する。
* topに表示される`socket_can_receiver`のCPU使用率が100%付近でないこと。
  * 参考：12th Gen Intel(R) Core(TM) i7-12700Fでは数%にも満たない使用率となる。
* Warning`[socket_can_receiver_node_exe-1] [WARN] [実行時の時間] [socket_can_receiver]: Error receiving CAN message: vcan0 - CAN Receive Timeout`が出力されないこと。

</p>
</details>

<details><summary>パターン2：interval_sec < 受信間隔</summary>
<p>

```sh
# Terminal-1
cangen vcan0 -g 21
```

```sh
# Terminal-2
top
```

```sh
# Terminal-3
ros2 launch ros2_socketcan socket_can_receiver.launch.py interface:='vcan0' interval_sec:='0.02'
```

上記を実施した状態で以下を確認する。
* topに表示される`socket_can_receiver`のCPU使用率が100%付近でないこと。
  * 参考：12th Gen Intel(R) Core(TM) i7-12700Fでは数%にも満たない使用率となる。
* Warning`[socket_can_receiver_node_exe-1] [WARN] [実行時の時間] [socket_can_receiver]: Error receiving CAN message: vcan0 - CAN Receive Timeout`が出力されること。

</p>
</details>

<details><summary>パターン3：timeout_sec > 送信間隔</summary>
<p>

```sh
# Terminal-1
 ros2 topic pub -r 51 /to_can_bus can_msgs/msg/Frame '{id: 512, dlc: 8}'
```

```sh
# Terminal-2
top
```

```sh
# Terminal-3
ros2 launch ros2_socketcan socket_can_sender.launch.py interface:='vcan0' timeout_sec:='0.02'
```

上記を実施した状態で以下を確認する。
* topに表示される`socket_can_sender`のCPU使用率が100%付近でないこと。
  * 参考：12th Gen Intel(R) Core(TM) i7-12700Fでは数%にも満たない使用率となる。
* Warning/Errorが出力されないこと。

</p>
</details>

## Notes for reviewers

None.

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
