### PR TITLE
feat: allow the socket to be reopened when the device is reconnected

### DIFF
--- a/include/ros2_socketcan/socket_can_common.hpp
+++ b/include/ros2_socketcan/socket_can_common.hpp
@@ -39,6 +39,8 @@ struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept;
 /// Create a fd_set for use with select() that only contains the specified file descriptor
 fd_set single_set(int32_t file_descriptor) noexcept;
 
+bool lost_device(int32_t file_descriptor) noexcept;
+
 }  // namespace socketcan
 }  // namespace drivers
 

--- a/include/ros2_socketcan/socket_can_receiver.hpp
+++ b/include/ros2_socketcan/socket_can_receiver.hpp
@@ -75,6 +75,8 @@ public:
     return ret;
   }
 
+  bool lost_device() const noexcept;
+
 private:
   // Wait for file descriptor to be available to send data via select()
   SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const;

--- a/include/ros2_socketcan/socket_can_receiver_node.hpp
+++ b/include/ros2_socketcan/socket_can_receiver_node.hpp
@@ -78,6 +78,7 @@ private:
   std::unique_ptr<SocketCanReceiver> receiver_;
   std::unique_ptr<std::thread> receiver_thread_;
   std::chrono::nanoseconds interval_ns_;
+  bool auto_socket_reopen_;
 
   // Diagnostic Updater
   diagnostic_updater::Updater updater_;

--- a/include/ros2_socketcan/socket_can_sender.hpp
+++ b/include/ros2_socketcan/socket_can_sender.hpp
@@ -105,6 +105,8 @@ public:
   /// Get the default CAN id
   CanId default_id() const noexcept;
 
+  bool lost_device() const noexcept;
+
 private:
   // Underlying implementation of sending, data is assumed to be of an appropriate length
   void send_impl(

--- a/include/ros2_socketcan/socket_can_sender_node.hpp
+++ b/include/ros2_socketcan/socket_can_sender_node.hpp
@@ -76,6 +76,7 @@ private:
   rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr frames_sub_;
   std::unique_ptr<SocketCanSender> sender_;
   std::chrono::nanoseconds timeout_ns_;
+  bool auto_socket_reopen_;
 
   // Diagnostic Updater
   diagnostic_updater::Updater updater_;

--- a/launch/socket_can_bridge.launch.xml
+++ b/launch/socket_can_bridge.launch.xml
@@ -3,15 +3,18 @@
   <arg name="interface" default="can0" />
   <arg name="receiver_interval_sec" default="0.01" />
   <arg name="sender_timeout_sec" default="0.01" />
+  <arg name="auto_socket_reopen" default="false"/>
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py">
     <arg name="interface" value="$(var interface)" />
     <arg name="interval_sec" value="$(var receiver_interval_sec)" />
+    <arg name="auto_socket_reopen" value="$(var auto_socket_reopen)" />
   </include>
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_sender.launch.py">
     <arg name="interface" value="$(var interface)" />
     <arg name="timeout_sec" value="$(var sender_timeout_sec)" />
+    <arg name="auto_socket_reopen" value="$(var auto_socket_reopen)" />
   </include>
 
 </launch>

--- a/launch/socket_can_receiver.launch.py
+++ b/launch/socket_can_receiver.launch.py
@@ -38,6 +38,7 @@ def generate_launch_description():
             'interface': LaunchConfiguration('interface'),
             'interval_sec':
             LaunchConfiguration('interval_sec'),
+            'auto_socket_reopen': LaunchConfiguration('auto_socket_reopen'),
         }],
         output='screen')
 
@@ -73,12 +74,67 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration('auto_activate')),
     )
 
+    socket_can_receiver_cleanup_event_handler = RegisterEventHandler(
+        event_handler=OnStateTransition(
+            target_lifecycle_node=socket_can_receiver_node,
+            start_state='deactivating',
+            goal_state='inactive',
+            entities=[
+                EmitEvent(
+                    event=ChangeState(
+                        lifecycle_node_matcher=matches_action(socket_can_receiver_node),
+                        transition_id=Transition.TRANSITION_CLEANUP,
+                    ),
+                ),
+            ],
+        ),
+        condition=IfCondition(LaunchConfiguration('auto_socket_reopen')),
+    )
+
+    socket_can_receiver_restart_event_handler = RegisterEventHandler(
+        event_handler=OnStateTransition(
+            target_lifecycle_node=socket_can_receiver_node,
+            start_state='cleaningup',
+            goal_state='unconfigured',
+            entities=[
+                EmitEvent(
+                    event=ChangeState(
+                        lifecycle_node_matcher=matches_action(socket_can_receiver_node),
+                        transition_id=Transition.TRANSITION_CONFIGURE,
+                    ),
+                ),
+            ],
+        ),
+        condition=IfCondition(LaunchConfiguration('auto_socket_reopen')),
+    )
+
+    socket_can_receiver_retry_configure_event_handler = RegisterEventHandler(
+        event_handler=OnStateTransition(
+            target_lifecycle_node=socket_can_receiver_node,
+            start_state='configuring',
+            goal_state='unconfigured',
+            entities=[
+                EmitEvent(
+                    event=ChangeState(
+                        lifecycle_node_matcher=matches_action(socket_can_receiver_node),
+                        transition_id=Transition.TRANSITION_CONFIGURE,
+                    ),
+                ),
+            ],
+        ),
+        condition=IfCondition(LaunchConfiguration('auto_socket_reopen')),
+    )
+
     return LaunchDescription([
         DeclareLaunchArgument('interface', default_value='can0'),
         DeclareLaunchArgument('interval_sec', default_value='0.01'),
         DeclareLaunchArgument('auto_configure', default_value='true'),
         DeclareLaunchArgument('auto_activate', default_value='true'),
+        DeclareLaunchArgument('auto_socket_reopen', default_value='false'),
         socket_can_receiver_node,
         socket_can_receiver_configure_event_handler,
         socket_can_receiver_activate_event_handler,
+        socket_can_receiver_cleanup_event_handler,
+        socket_can_receiver_restart_event_handler,
+        socket_can_receiver_retry_configure_event_handler,
     ])

--- a/src/socket_can_common.cpp
+++ b/src/socket_can_common.cpp
@@ -101,5 +101,24 @@ fd_set single_set(int32_t file_descriptor) noexcept
 
   return descriptor_set;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+bool lost_device(int32_t file_descriptor) noexcept
+{
+
+  struct sockaddr_can addr;
+  socklen_t len = sizeof(addr);
+  if(0 != getsockname(file_descriptor, reinterpret_cast<struct sockaddr *>(&addr), &len)) {
+    return true;
+  }
+
+  struct ifreq ifr;
+  ifr.ifr_ifindex = addr.can_ifindex;
+  if (0 != ioctl(file_descriptor, static_cast<uint32_t>(SIOCGIFNAME), &ifr)) {
+    return true;
+  }
+
+  return false;
+}
 }  // namespace socketcan
 }  // namespace drivers

--- a/src/socket_can_receiver.cpp
+++ b/src/socket_can_receiver.cpp
@@ -83,5 +83,11 @@ CanId SocketCanReceiver::receive(void * const data, const std::chrono::nanosecon
   return CanId{frame.can_id, data_length};
 }
 
+////////////////////////////////////////////////////////////////////////////////
+bool SocketCanReceiver::lost_device() const noexcept
+{
+  return drivers::socketcan::lost_device(m_file_descriptor);
+}
+
 }  // namespace socketcan
 }  // namespace drivers

--- a/src/socket_can_receiver_node.cpp
+++ b/src/socket_can_receiver_node.cpp
@@ -144,9 +144,11 @@ void SocketCanReceiverNode::receive()
         "Error receiving CAN message: %s - %s",
         interface_.c_str(), ex.what());
       if (auto_socket_reopen_) {
-        updater_.force_update();
-        this->deactivate();
-        return;
+        if (receiver_->lost_device()) {
+          updater_.force_update();
+          this->deactivate();
+          return;
+        }
       }
       continue;
     }

--- a/src/socket_can_receiver_node.cpp
+++ b/src/socket_can_receiver_node.cpp
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 
 namespace lc = rclcpp_lifecycle;
@@ -38,6 +39,7 @@ SocketCanReceiverNode::SocketCanReceiverNode(rclcpp::NodeOptions options)
   double interval_sec = this->declare_parameter("interval_sec", 0.01);
   interval_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
     std::chrono::duration<double>(interval_sec));
+  auto_socket_reopen_ = this->declare_parameter("auto_socket_reopen", false);
 
   // Diagnostic Updater
   updater_.setHardwareID("socket_can_receiver");
@@ -46,6 +48,9 @@ SocketCanReceiverNode::SocketCanReceiverNode(rclcpp::NodeOptions options)
 
   RCLCPP_INFO(this->get_logger(), "interface: %s", interface_.c_str());
   RCLCPP_INFO(this->get_logger(), "interval(s): %f", interval_sec);
+  RCLCPP_INFO(
+    this->get_logger(), "auto_socket_reopen: %s",
+    auto_socket_reopen_ ? "true" : "false");
 }
 
 LNI::CallbackReturn SocketCanReceiverNode::on_configure(const lc::State & state)
@@ -58,6 +63,7 @@ LNI::CallbackReturn SocketCanReceiverNode::on_configure(const lc::State & state)
     RCLCPP_ERROR(
       this->get_logger(), "Error opening CAN receiver: %s - %s",
       interface_.c_str(), ex.what());
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     return LNI::CallbackReturn::FAILURE;
   }
 
@@ -137,6 +143,11 @@ void SocketCanReceiverNode::receive()
         this->get_logger(), *this->get_clock(), 1000,
         "Error receiving CAN message: %s - %s",
         interface_.c_str(), ex.what());
+      if (auto_socket_reopen_) {
+        updater_.force_update();
+        this->deactivate();
+        return;
+      }
       continue;
     }
     updater_.force_update();

--- a/src/socket_can_sender.cpp
+++ b/src/socket_can_sender.cpp
@@ -114,5 +114,10 @@ void SocketCanSender::send_impl(
   }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+bool SocketCanSender::lost_device() const noexcept
+{
+  return drivers::socketcan::lost_device(m_file_descriptor);
+}
 }  // namespace socketcan
 }  // namespace drivers

--- a/src/socket_can_sender_node.cpp
+++ b/src/socket_can_sender_node.cpp
@@ -138,7 +138,9 @@ void SocketCanSenderNode::on_frame(const can_msgs::msg::Frame::SharedPtr msg)
         "Error sending CAN message: %s - %s",
         interface_.c_str(), ex.what());
       if (auto_socket_reopen_) {
-        this->deactivate();
+        if (sender_->lost_device()) {
+          this->deactivate();
+        }
       }
     }
     updater_.force_update();


### PR DESCRIPTION
## Description

USB接続のCANデバイスを抜き差ししてもCAN通信を復帰させたいニーズがあり、CANデバイスを抜き差ししてもCAN通信が復帰するように修正。

USB接続のCANデバイスは抜き差しにより、インターフェース番号が変化する。udevでインターフェース名を固定にしたとしても、インターフェース番号は変化する。socketcanではインターフェース番号により、ソケットとCANデバイスを紐づけており、同じデバイスを再接続しても通信は復帰しない。

CANデバイスを抜き差ししても通信が復帰するよう、インターフェース番号を再取得してのソケットを再オープンする処理を実装する。また、auto_socket_reopenパラメータを設け、再オープンするか、再オープンしないか(変更前と同じふるまいにする)を選択可能とする。

<!-- Write a brief description of this PR. -->

## Related links

* Jira ticket
    * [Ticket (COMPANY INTERNAL LINK)]
      * 本PRの契機となった、CANデバイスを抜き差ししてもCAN通信を復活させたいニーズの件のチケット。
* Design
    * [Proposed change (COMPANY INTERNAL LINK)]
      * 再オープンの変更案の検討。
        * 最終的にROS2のLifecycleを使い、CANデバイスが見つからないことを検出したら起動直後の状態まで遷移し、ソケットオープンからやり直す仕組みを採用することとした。
        * Active状態からErrorに遷移するトリガーがROS2に実装されていないことから、Deactivatingを経由するLifecycleとしている。
    * [Design (COMPANY INTERNAL LINK)]
      * 再オープンの採用案の適用方法。
    * [Testing with ECUs (COMPANY INTERNAL LINK)]
      * ベンチ/実車によるテスト項目。

[Ticket (COMPANY INTERNAL LINK)]: https://tier4.atlassian.net/browse/AEAP-438
[Proposed change (COMPANY INTERNAL LINK)]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/2673344513/USB-CAN+OFF#Socket%E5%86%8D%E3%82%AA%E3%83%BC%E3%83%97%E3%83%B3%E8%A8%AD%E8%A8%88%E6%A1%88
[Design (COMPANY INTERNAL LINK)]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/2673344513/USB-CAN+OFF#Socket%E5%86%8D%E3%82%AA%E3%83%BC%E3%83%97%E3%83%B3%E8%A8%AD%E8%A8%88
[Testing with ECUs (COMPANY INTERNAL LINK)]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/2673344513/USB-CAN+OFF#%E3%83%99%E3%83%B3%E3%83%81%2F%E5%AE%9F%E6%A9%9F%E3%81%AB%E3%81%8A%E3%81%91%E3%82%8B%E6%A4%9C%E6%9F%BB%E9%A0%85%E7%9B%AE

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

### 開発PC環境におけるテスト

1. 再オープンの有無とUSB-CANの接続状況により、CAN通信の挙動が以下の通りであることを確認。
   * 再オープンなしの時
      * ノード起動中にUSB-CANデバイスを抜き差ししても通信が復帰しないことを確認。
      * ノード起動後にUSB-CANデバイスを繋いでも通信が開始しないことを確認。
      * ノード起動後にUSB-CANデバイスをリンクダウンしても、CAN通信せず、ソケットを再生成しないことを確認。
      * ノード起動後にUSB-CANデバイスをリンクダウン->リンクアップすることで、CAN通信を再開することを確認。
   * 再オープンありの時
      * ノード起動中にUSB-CANデバイスを抜き差ししても通信が復帰することを確認。
      * ノード起動後にUSB-CANデバイスを繋いでも通信が開始することを確認。
      * ノード起動後にUSB-CANデバイスをリンクダウンしても、CAN通信せず、ソケットを再生成しないことを確認。
      * ノード起動後にUSB-CANデバイスをリンクダウン->リンクアップすることで、CAN通信を再開することを確認。
2. Diagトピックについて以下の挙動であることを確認。
   * パターン
      * ノード起動時にCANデバイスが接続されていない時は、Diagとしてエラーなしを出力していることを確認(変更前に同じ)。
      * USB-CANをリンクダウンした後、CAN通信の異常が確定した時点で、Diagとしてエラーを出力していることを確認。
      * USB-CANを抜去した後、CAN通信の異常が確定した時点で、Diagとしてエラーを出力していることを確認。
      * USB-CANをリンクダウン->リンクアップした後、CAN通信が正常復帰した時点で、Diagとしてエラーなしを出力していることを確認。
         * 再オープンなしの時：Diagがエラーなしとなる。(リンクダウンまでならば、ソケット再生成は不要であり、リンクアップで復帰できる)
         * 再オープンありの時：Diagがエラーなしとなる。
      * USB-CANを再接続した後、CAN通信が正常復帰した時点で、Diagとしてエラーなしを出力していることを確認。
         * 再オープンなしの時：正常に復帰するトリガーがないことから、Diagのエラー出力が継続する。
         * 再オープンありの時：Diagがエラーなしとなる。
   * Diagのエラー発生/解消の詳細
      * Diagのエラーの状態が変わるのは以下の通り。CANデバイスの接続状態が変化しても、次の条件を満たさなければ、Diagのエラーは変化しない。
      * Diagがエラーとなるタイミング
         * socket_can_senderは、トピックを受信しCANバスへCANフレームを送信するタイミングで送れなければDiagはエラーとなる。
         * socket_can_receiverは、CANバスからCANフレームが一定時間到着せず、タイムアウトした時点でDiagはエラーとなる。
      * Diagがエラーなしとなるタイミング
         * socket_can_senderは、トピックを受信しCANバスへCANフレームを送信できたらDiagがエラーなしとなる。
         * socket_can_receiverは、CANバスからCANフレームが到着した時点でDiagがエラーなしとなる。
3. launchに追加したパラメータ`auto_socket_reopen`について、ソケットの再オープンに正しく作用していることを確認。
   * 対象launch
      * socket_can_receiver.launch.py
      * socket_can_sender.launch.py
      * socket_can_bridge.launch.xml
   * `auto_socket_reopen`の作用
      * true:ソケットを再オープンし、CAN通信が復帰すること。
      * false:ソケットを再オープンせず、CAN通信が復帰しないこと。

上記の詳細な実施条件等は以下の通り。

1. [Testing Statemachine (COMPANY INTERNAL LINK)]
2. [Testing Diagnostics (COMPANY INTERNAL LINK)]
3. [Testing Launch (COMPANY INTERNAL LINK)]

[Testing Statemachine (COMPANY INTERNAL LINK)]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/2673344513/USB-CAN+OFF#ros2_socketcan%E3%81%AE%E7%8A%B6%E6%85%8B%E9%81%B7%E7%A7%BB%E3%81%AB%E5%AF%BE%E3%81%99%E3%82%8B%E6%A4%9C%E6%9F%BB
[Testing Diagnostics (COMPANY INTERNAL LINK)]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/2673344513/USB-CAN+OFF#ros2_socketcan%E3%81%AEDiag%E5%87%BA%E5%8A%9B%E3%81%AB%E5%AF%BE%E3%81%99%E3%82%8B%E6%A4%9C%E6%9F%BB
[Testing Launch (COMPANY INTERNAL LINK)]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/2673344513/USB-CAN+OFF#ros2_socketcan%E3%81%AELaunch%E3%81%AB%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%9F%E5%BC%95%E6%95%B0%E3%81%AB%E5%AF%BE%E3%81%99%E3%82%8B%E6%A4%9C%E6%9F%BB

### ベンチ/実車におけるテスト

**Tests are coming up.**

* OTAによるセットアップが完了後、USB-CANデバイスの抜去が行われても、シャットダウンが実行できることを確認。
* OTAによるセットアップが完了後、自動運転で走行できることを確認(デグレ確認)。

上記の詳細な実施条件等は、[Testing with ECUs (COMPANY INTERNAL LINK)]を参照。
